### PR TITLE
Small improvements

### DIFF
--- a/ConsoleLogonUI/ui/gina_manager.cpp
+++ b/ConsoleLogonUI/ui/gina_manager.cpp
@@ -61,7 +61,7 @@ void ginaManager::LoadGina()
 							{
 								ginaVersion = GINA_VER_2K;
 							}
-							else if (major == 5 && minor == 1)
+							else if (major == 5 && (minor == 1 || minor == 2))
 							{
 								ginaVersion = GINA_VER_XP;
 							}

--- a/ConsoleLogonUI/ui/wallhost.cpp
+++ b/ConsoleLogonUI/ui/wallhost.cpp
@@ -167,7 +167,7 @@ void wallHost::Create()
 	wc.hInstance = hInstance;
 	wc.lpszClassName = L"ClhGinaWallHost";
 	RegisterClass(&wc);
-	wallHost::Get()->hWnd = CreateWindowExW(0, L"ClhGinaWallHost", L"CLH_GINA Wallpaper Host", WS_POPUP | WS_VISIBLE, 0, 0, screenRect.right, screenRect.bottom, 0, 0, hInstance, 0);
+	wallHost::Get()->hWnd = CreateWindowExW(WS_EX_TOOLWINDOW, L"ClhGinaWallHost", L"CLH_GINA Wallpaper Host", WS_POPUP | WS_VISIBLE, 0, 0, screenRect.right, screenRect.bottom, 0, 0, hInstance, 0);
 	SetWindowPos(wallHost::Get()->hWnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 
 	LoadWallpaper();


### PR DESCRIPTION
- Support MSGINA.dll from NT 5.2 (Server 2003 and XP x64 Edition)
- Add `WS_EX_TOOLWINDOW` style to wallpaper host to prevent it showing up in ALT+TAB